### PR TITLE
fix: Issue with `is_subclass_of` for types that are not compatible with `issubclass`.

### DIFF
--- a/tests/test_type_view.py
+++ b/tests/test_type_view.py
@@ -257,7 +257,14 @@ def test_parsed_type_is_optional_predicate() -> None:
 
 
 def test_parsed_type_is_subtype_of() -> None:
-    """Test ParsedType.is_type_of."""
+    """Test TypeView.is_subtype_of."""
+
+    class Foo:
+        pass
+
+    class Bar(Foo):
+        pass
+
     assert TypeView(bool).is_subtype_of(int) is True
     assert TypeView(bool).is_subtype_of(str) is False
     assert TypeView(Union[int, str]).is_subtype_of(int) is False
@@ -265,6 +272,31 @@ def test_parsed_type_is_subtype_of() -> None:
     assert TypeView(List[int]).is_subtype_of(int) is False
     assert TypeView(Optional[int]).is_subtype_of(int) is False
     assert TypeView(Union[bool, int]).is_subtype_of(int) is True
+
+    assert TypeView(Foo).is_subtype_of(Foo) is True
+    assert TypeView(Bar).is_subtype_of(Foo) is True
+
+
+def test_is_subclass_of() -> None:
+    class Foo:
+        pass
+
+    class Bar(Foo):
+        pass
+
+    assert TypeView(bool).is_subclass_of(int) is True
+    assert TypeView(bool).is_subclass_of(str) is False
+    assert TypeView(Union[int, str]).is_subclass_of(int) is False
+    assert TypeView(List[int]).is_subclass_of(int) is False
+    assert TypeView(Optional[int]).is_subclass_of(int) is False
+    assert TypeView(None).is_subclass_of(int) is False
+    assert TypeView(Literal[1]).is_subclass_of(int) is False
+    assert TypeView(Union[bool, int]).is_subclass_of(int) is False
+
+    assert TypeView(bool).is_subclass_of(bool) is True
+    assert TypeView(List[int]).is_subclass_of(list) is True
+    assert TypeView(Foo).is_subclass_of(Foo) is True
+    assert TypeView(Bar).is_subclass_of(Foo) is True
 
 
 def test_parsed_type_has_inner_subtype_of() -> None:

--- a/type_lens/type_view.py
+++ b/type_lens/type_view.py
@@ -224,6 +224,18 @@ class TypeView(Generic[T]):
             return issubclass(str, typ) or issubclass(bytes, typ)
         return self.annotation is not Any and not self.is_type_var and issubclass(self.annotation, typ)
 
+    def is_subclass_of(self, typ: Any | tuple[Any, ...], /) -> bool:
+        """Whether the annotation is a subclass of the given type.
+
+        Args:
+            typ: The type to check, or tuple of types. Passed as 2nd argument to ``issubclass()``.
+
+        Returns:
+            Whether the annotation is a subclass of the given type(s).
+        """
+        origin = self.origin or self.annotation
+        return isinstance(origin, type) and issubclass(origin, typ)
+
     def strip_optional(self) -> TypeView:
         if not self.is_optional:
             return self

--- a/type_lens/type_view.py
+++ b/type_lens/type_view.py
@@ -233,8 +233,7 @@ class TypeView(Generic[T]):
         Returns:
             Whether the annotation is a subclass of the given type(s).
         """
-        origin = self.origin or self.annotation
-        return isinstance(origin, type) and issubclass(origin, typ)
+        return isinstance(self.fallback_origin, type) and issubclass(self.fallback_origin, typ)
 
     def strip_optional(self) -> TypeView:
         if not self.is_optional:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
Certain input types (exemplified in the test additions) fail `issubclass` and need to be guarded against.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->