### PR TITLE
feat: Add strip_optional method to TypeView.

### DIFF
--- a/tests/test_type_view.py
+++ b/tests/test_type_view.py
@@ -292,3 +292,12 @@ def test_tuple():
 
     assert TypeView(tuple[int, ...]).is_tuple is True
     assert TypeView(tuple[int, ...]).is_variadic_tuple is True
+
+
+def test_strip_optional() -> None:
+    # Non-optionals should return the original input
+    assert TypeView(int).strip_optional() == TypeView(int)
+
+    assert TypeView(Optional[int]).strip_optional() == TypeView(int)
+    assert TypeView(Optional[Union[str, int]]).strip_optional() == TypeView(Union[str, int])
+    assert TypeView(Union[str, int, None]).strip_optional() == TypeView(Union[str, int])

--- a/type_lens/type_view.py
+++ b/type_lens/type_view.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import abc
 from collections.abc import Collection, Mapping
-from typing import Annotated, Any, AnyStr, Final, ForwardRef, TypeVar
+from typing import Annotated, Any, AnyStr, Final, ForwardRef, TypeVar, Union
 
 from typing_extensions import NotRequired, Required, get_args, get_origin
 
@@ -146,3 +146,14 @@ class TypeView:
             Whether any of the type's generic args are a subclass of the given type.
         """
         return any(t.is_subclass_of(cl) for t in self.inner_types)
+
+    def strip_optional(self) -> TypeView:
+        if not self.is_optional:
+            return self
+
+        if len(self.args) == 2:
+            return self.inner_types[0]
+
+        args = tuple([a for a in self.args if a is not NoneType])
+        non_optional = Union[args]
+        return TypeView(non_optional)

--- a/type_lens/type_view.py
+++ b/type_lens/type_view.py
@@ -154,6 +154,6 @@ class TypeView:
         if len(self.args) == 2:
             return self.inner_types[0]
 
-        args = tuple([a for a in self.args if a is not NoneType])
+        args = tuple(a for a in self.args if a is not NoneType)
         non_optional = Union[args]
         return TypeView(non_optional)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
Adds a method which allows removing the "optional" component of an input type that `is_optional`

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
Fixes https://github.com/litestar-org/type-lens/issues/8