### PR TITLE
feat: Add is_variadic_tuple to TypeView.

### DIFF
--- a/tests/test_type_view.py
+++ b/tests/test_type_view.py
@@ -278,3 +278,17 @@ def test_parsed_type_equality() -> None:
     assert TypeView(list[int]) != TypeView(list[str])
     assert TypeView(list[str]) != TypeView(tuple[str])
     assert TypeView(Optional[str]) == TypeView(Union[str, None])
+
+
+def test_tuple():
+    assert TypeView(list[int]).is_tuple is False
+    assert TypeView(list[int]).is_variadic_tuple is False
+
+    assert TypeView(tuple[int]).is_tuple is True
+    assert TypeView(tuple[int]).is_variadic_tuple is False
+
+    assert TypeView(tuple[int, int]).is_tuple is True
+    assert TypeView(tuple[int, int]).is_variadic_tuple is False
+
+    assert TypeView(tuple[int, ...]).is_tuple is True
+    assert TypeView(tuple[int, ...]).is_variadic_tuple is True

--- a/type_lens/type_view.py
+++ b/type_lens/type_view.py
@@ -81,6 +81,15 @@ class TypeView:
         return self.is_subclass_of(tuple)
 
     @property
+    def is_variadic_tuple(self) -> bool:
+        """Whether the annotation is a ``tuple`` **and** is of unbounded length.
+
+        Tuples like `tuple[int, ...]` represent a list-like unbounded sequence
+        of a single type T.
+        """
+        return self.is_tuple and len(self.args) == 2 and self.args[1] == ...
+
+    @property
     def is_type_var(self) -> bool:
         """Whether the annotation is a TypeVar or not."""
         return isinstance(self.annotation, TypeVar)


### PR DESCRIPTION
## Description

- Adds a property to indicate if a tuple is an "arbitrary-length homogeneous tuple" tuple.

I.e. `tuple[int, str]` and `tuple[int, ...]` which are distinct kinds of types that have different semantics as far as the type checkers go.

I dont know if there's a canonical name for this or not, is the main consideration in my mind.