### PR TITLE
fix: Mark standalone None as is_optional.

### DIFF
--- a/tests/test_type_view.py
+++ b/tests/test_type_view.py
@@ -15,6 +15,7 @@ from typing import (
 
 import pytest
 from type_lens import TypeView
+from type_lens.types.builtins import NoneType
 from typing_extensions import NotRequired, Required
 
 if TYPE_CHECKING:
@@ -250,6 +251,8 @@ def test_parsed_type_is_optional_predicate() -> None:
     assert TypeView(Union[int, None]).is_optional is True
     assert TypeView(Union[int, None, str]).is_optional is True
     assert TypeView(Union[int, str]).is_optional is False
+    assert TypeView(NoneType).is_optional is True
+    assert TypeView(None).is_optional is True
 
 
 def test_parsed_type_is_subclass_of() -> None:

--- a/type_lens/type_view.py
+++ b/type_lens/type_view.py
@@ -93,7 +93,7 @@ class TypeView:
     @property
     def is_optional(self) -> bool:
         """Whether the annotation is Optional or not."""
-        return bool(self.is_union and NoneType in self.args)
+        return bool(self.is_union and NoneType in self.args) or self.annotation in {None, NoneType}
 
     @property
     def is_collection(self) -> bool:


### PR DESCRIPTION
## Description

This is not generally meaningful, because something is not really ever going to be annotated as `foo: None`.

However, when writing code that operates over something like `for t in TypeView(int | None).inner_types`, it can come up.

Perhaps in concert with https://github.com/litestar-org/type-lens/pull/10, I might be able to _avoid_ it, but... (it only occurred to me in writing this description :P), it maybe seems like the logical extension of:
```python
assert TypeView(str | int | None).is_optional is True
assert TypeView(int | None).is_optional is True
assert TypeView(None).is_optional is True
```