### PR TITLE
feat: Add repr to TypeView that mirrors the input.

### DIFF
--- a/tests/test_type_view.py
+++ b/tests/test_type_view.py
@@ -6,6 +6,7 @@ from typing import (
     Annotated,
     Any,
     ForwardRef,
+    Literal,
     Optional,
     TypedDict,
     TypeVar,
@@ -292,3 +293,9 @@ def test_tuple():
 
     assert TypeView(tuple[int, ...]).is_tuple is True
     assert TypeView(tuple[int, ...]).is_variadic_tuple is True
+
+
+def test_repr():
+    assert repr(TypeView(int)) == "TypeView(int)"
+    assert repr(TypeView(Optional[str])) == "TypeView(typing.Optional[str])"
+    assert repr(TypeView(Literal["1", 2, True])) == "TypeView(typing.Literal['1', 2, True])"

--- a/type_lens/type_view.py
+++ b/type_lens/type_view.py
@@ -65,6 +65,14 @@ class TypeView:
 
         return bool(self.annotation == other.annotation)
 
+    def __repr__(self) -> str:
+        cls_name = self.__class__.__name__
+
+        raw = self.raw
+        if isinstance(self.raw, type):
+            raw = raw.__name__
+        return f"{cls_name}({raw})"
+
     @property
     def is_forward_ref(self) -> bool:
         """Whether the annotation is a forward reference or not."""


### PR DESCRIPTION
## Description

Mostly just because it's really convenient when debugging the code using this that you can see `TypeView(int)` or `TypeView(list[int])`.

I could imagine putting more effort into stripping module from stuff like `typing.List`, that you get now. Or alternatively, I could imagine using `__qualname__` and leaning into being unambiguous about the type source.

The `type` conditional is specifically to avoid getting `TypeVar(<class Foo jalkdjfz>)`