### PR TITLE
feat: Make TypeView generic on its input type. 

### DIFF
--- a/type_lens/type_view.py
+++ b/type_lens/type_view.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import abc
 from collections.abc import Collection, Mapping
-from typing import Annotated, Any, AnyStr, Final, ForwardRef, TypeVar
+from typing import Annotated, Any, AnyStr, Final, ForwardRef, Generic, TypeVar
 
 from typing_extensions import NotRequired, Required, get_args, get_origin
 
@@ -12,7 +12,10 @@ from type_lens.utils import get_instantiable_origin, unwrap_annotation
 __all__ = ("TypeView",)
 
 
-class TypeView:
+T = TypeVar("T")
+
+
+class TypeView(Generic[T]):
     """Represents a type annotation."""
 
     __slots__ = {
@@ -29,7 +32,7 @@ class TypeView:
         "raw": "The annotation exactly as received.",
     }
 
-    def __init__(self, annotation: Any) -> None:
+    def __init__(self, annotation: T) -> None:
         """Initialize ParsedType.
 
         Args:
@@ -45,7 +48,7 @@ class TypeView:
 
         args = () if origin is abc.Callable else get_args(unwrapped)
 
-        self.raw: Final = annotation
+        self.raw: Final[T] = annotation
         self.annotation: Final = unwrapped
         self.origin: Final = origin
         self.args: Final = args


### PR DESCRIPTION
## Description

There is little to no practical benefit for any of the API I see so far.

However, I found it useful in downstream code signatures like `def parse_value(annotation: TypeView[T]) -> typing.Callable[[typing.Any], T]:`