### PR TITLE
feat: Add is_literal to TypeView.

### DIFF
--- a/tests/test_type_view.py
+++ b/tests/test_type_view.py
@@ -308,3 +308,9 @@ def test_repr():
     assert repr(TypeView(int)) == "TypeView(int)"
     assert repr(TypeView(Optional[str])) == "TypeView(typing.Optional[str])"
     assert repr(TypeView(Literal["1", 2, True])) == "TypeView(typing.Literal['1', 2, True])"
+
+
+def test_literal():
+    assert TypeView(int).is_literal is False
+    assert TypeView(Literal[4]).is_literal is True
+    assert TypeView(4).is_literal is False

--- a/type_lens/type_view.py
+++ b/type_lens/type_view.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import abc
 from collections.abc import Collection, Mapping
-from typing import Annotated, Any, AnyStr, Final, ForwardRef, Generic, TypeVar, Union
+from typing import Annotated, Any, AnyStr, Final, ForwardRef, Generic, Literal, TypeVar, Union
 
 from typing_extensions import NotRequired, Required, get_args, get_origin
 
@@ -119,6 +119,11 @@ class TypeView(Generic[T]):
     def is_collection(self) -> bool:
         """Whether the annotation is a collection type or not."""
         return self.is_subclass_of(Collection)
+
+    @property
+    def is_literal(self) -> bool:
+        """Whether the annotation is a literal value or not."""
+        return self.origin is Literal
 
     @property
     def is_non_string_collection(self) -> bool:


### PR DESCRIPTION
## Description

The `typing_inspect` implementation of this is significantly more complicated than my super simple check. But it is also handling earlier python versions.

Fwiw, the current impl returns `TypeView(Literal).is_literal == False`. I'm just not sure what this would even mean, and it seems like type checkers dont allow you to define a standalone Literal anyways...because it's meaningless(?)