### PR TITLE
feat: Add is_none_type to TypeView.

### DIFF
--- a/tests/test_type_view.py
+++ b/tests/test_type_view.py
@@ -16,6 +16,7 @@ from typing import (
 
 import pytest
 from type_lens import TypeView
+from type_lens.type_view import NoneType
 from typing_extensions import NotRequired, Required
 
 if TYPE_CHECKING:
@@ -308,3 +309,11 @@ def test_repr():
     assert repr(TypeView(int)) == "TypeView(int)"
     assert repr(TypeView(Optional[str])) == "TypeView(typing.Optional[str])"
     assert repr(TypeView(Literal["1", 2, True])) == "TypeView(typing.Literal['1', 2, True])"
+
+
+def test_is_none_type():
+    assert TypeView(int).is_none_type is False
+    assert TypeView(None).is_none_type is True
+    assert TypeView(NoneType).is_none_type is True
+    assert TypeView(Annotated[None, 4]).is_none_type is True
+    assert TypeView(Union[int, None]).inner_types[1].is_none_type is True

--- a/type_lens/type_view.py
+++ b/type_lens/type_view.py
@@ -125,6 +125,7 @@ class TypeView(Generic[T]):
         """Whether the annotation is NoneType or not."""
         return self.annotation in {None, NoneType}
 
+    @property
     def is_literal(self) -> bool:
         """Whether the annotation is a literal value or not."""
         return self.origin is Literal

--- a/type_lens/type_view.py
+++ b/type_lens/type_view.py
@@ -125,7 +125,6 @@ class TypeView(Generic[T]):
         """Whether the annotation is NoneType or not."""
         return self.annotation in {None, NoneType}
 
-
     def is_literal(self) -> bool:
         """Whether the annotation is a literal value or not."""
         return self.origin is Literal

--- a/type_lens/type_view.py
+++ b/type_lens/type_view.py
@@ -121,6 +121,11 @@ class TypeView(Generic[T]):
         return self.is_subclass_of(Collection)
 
     @property
+    def is_none_type(self) -> bool:
+        """Whether the annotation is NoneType or not."""
+        return self.annotation in {None, NoneType}
+
+    @property
     def is_non_string_collection(self) -> bool:
         """Whether the annotation is a non-string collection type or not."""
         return self.is_collection and not self.is_subclass_of((str, bytes))


### PR DESCRIPTION
## Description

Adds property `is_none_type` to demonstrate whether the view is of an annotation of `None`, or `NoneType`.