### PR TITLE
feat: `TypeView.allows_none` property

### DIFF
--- a/tests/test_type_view.py
+++ b/tests/test_type_view.py
@@ -323,3 +323,9 @@ def test_literal():
     assert TypeView(int).is_literal is False
     assert TypeView(Literal[4]).is_literal is True
     assert TypeView(4).is_literal is False
+
+
+def test_allows_none():
+    assert TypeView(int).allows_none is False
+    assert TypeView(Optional[int]).allows_none is True
+    assert TypeView(None).allows_none is True

--- a/type_lens/type_view.py
+++ b/type_lens/type_view.py
@@ -77,6 +77,11 @@ class TypeView(Generic[T]):
         return f"{cls_name}({raw})"
 
     @property
+    def allows_none(self) -> bool:
+        """Whether the annotation supports being assigned ``None``."""
+        return self.is_optional or self.is_none_type
+
+    @property
     def is_forward_ref(self) -> bool:
         """Whether the annotation is a forward reference or not."""
         return isinstance(self.annotation, (str, ForwardRef))


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Property that indicates whether `None` can be assigned to the annotation.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
