### PR TITLE
refactor: fix inconsistent use of attributes and properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ mypy:                                               ## Run mypy
 .PHONY: mypy-nocache
 mypy-nocache:                                       ## Run Mypy without cache
 	@echo "=> Running mypy without a cache"
-	@$(PDM) run dmypy run -- --cache-dir=/dev/null
+	@$(PDM) run mypy
 	@echo "=> mypy complete"
 
 .PHONY: pyright
@@ -102,8 +102,14 @@ pre-commit: 										## Runs pre-commit hooks; includes ruff formatting and lin
 	@$(PDM) run pre-commit run --all-files
 	@echo "=> Pre-commit complete"
 
+.PHONY: slotscheck
+slotscheck: 										## Run slotscheck
+	@echo "=> Running slotscheck"
+	@$(PDM) run slotscheck type_lens/
+	@echo "=> slotscheck complete"
+
 .PHONY: lint
-lint: pre-commit type-check 						## Run all linting
+lint: pre-commit type-check slotscheck						## Run all linting
 
 .PHONY: coverage
 coverage:  											## Run the tests and generate coverage report


### PR DESCRIPTION

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR moves a few of the `is_...` predicates to `@property` definitions, consistent with the others.

It also reorganises the class members in order of `@properties` followed by `def`s, and alphabetically sorts within each member type.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
