### PR TITLE
feat: Expose the Empty and EmptyType types.

### DIFF
--- a/type_lens/__init__.py
+++ b/type_lens/__init__.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from .parameter_view import ParameterView
 from .type_view import TypeView
+from .types.empty import Empty, EmptyType
 
 __all__ = (
     "ParameterView",
     "TypeView",
+    "EmptyType",
+    "Empty",
 )

--- a/type_lens/types/empty.py
+++ b/type_lens/types/empty.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing_extensions import TypeAlias
+
 __all__ = ("Empty", "EmptyType")
 
 from enum import Enum
@@ -12,5 +14,5 @@ class _EmptyEnum(Enum):
     EMPTY = 0
 
 
-EmptyType = Literal[_EmptyEnum.EMPTY]
+EmptyType: TypeAlias = Literal[_EmptyEnum.EMPTY]
 Empty: Final = _EmptyEnum.EMPTY


### PR DESCRIPTION
`Empty` and `EmptyType` are implicitly exposed already through `ParameterView`'s `default` field already.

Further, this sort of type is just useful for the sorts of libraries who will use this library for modelling lack of an input value in a typed way.