### PR TITLE
fix: Apply strict typing.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "type-lens"
-version = "0.2.3"
+version = "0.2.4"
 description = "type-lens is a Python template project designed to simplify the setup of a new project."
 readme = "README.md"
 license = { text = "MIT" }
@@ -127,6 +127,7 @@ warn_unused_configs = true
 warn_unused_ignores = true
 
 [tool.pyright]
+typeCheckingMode = "strict"
 disableBytesTypePromotions = true
 exclude = [
     "tools",

--- a/tests/test_callable_view.py
+++ b/tests/test_callable_view.py
@@ -44,9 +44,9 @@ def test_return_annotation() -> None:
 
 def test_untyped_param() -> None:
     def fn(foo):  # type: ignore[no-untyped-def]
-        return foo
+        return foo  # pyright: ignore
 
-    function_view = CallableView.from_callable(fn)
+    function_view = CallableView.from_callable(fn)  # pyright: ignore
     assert function_view.parameters == (ParameterView("foo", TypeView(Any), has_annotation=False),)
 
 
@@ -127,7 +127,7 @@ def test_instance_method() -> None:
 def test_parameters_with_none_default(hint: Any) -> None:
     def fn(plain: hint = None, annotated: Annotated[hint, ...] = None) -> None: ...  # pyright: ignore
 
-    fn_view = CallableView.from_callable(fn, localns=locals(), include_extras=True)
+    fn_view = CallableView.from_callable(fn, localns=locals(), include_extras=True)  # pyright: ignore
     plain_param, annotated_param = fn_view.parameters
     assert plain_param.type_view.annotation == annotated_param.type_view.annotation
 

--- a/tests/test_type_view.py
+++ b/tests/test_type_view.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-def _check_parsed_type(type_lens: TypeView, expected: dict[str, Any]) -> None:
+def _check_parsed_type(type_lens: TypeView[Any], expected: dict[str, Any]) -> None:
     __tracebackhide__ = True
     for key, expected_value in expected.items():
         lens_value = getattr(type_lens, key)
@@ -334,8 +334,8 @@ def test_tuple() -> None:
     assert TypeView(Tuple[int, ...]).is_tuple is True
     assert TypeView(Tuple[int, ...]).is_variadic_tuple is True
 
-    assert TypeView(...).is_tuple is False
-    assert TypeView(...).is_variadic_tuple is False
+    assert TypeView(...).is_tuple is False  # pyright: ignore
+    assert TypeView(...).is_variadic_tuple is False  # pyright: ignore
 
 
 def test_strip_optional() -> None:

--- a/type_lens/parameter_view.py
+++ b/type_lens/parameter_view.py
@@ -32,7 +32,7 @@ class ParameterView:
     def __init__(
         self,
         name: str,
-        type_view: TypeView = _any_type_view,
+        type_view: TypeView[Any] = _any_type_view,
         *,
         default: Any | EmptyType = Empty,
         has_annotation: bool = True,

--- a/type_lens/typing.py
+++ b/type_lens/typing.py
@@ -44,7 +44,7 @@ if sys.version_info >= (3, 10):
     _get_type_hints = typing.get_type_hints  # pyright: ignore
 
 else:
-    from eval_type_backport import eval_type_backport
+    from eval_type_backport import eval_type_backport  # pyright: ignore
 
     @typing.no_type_check
     def _get_type_hints(  # noqa: C901

--- a/type_lens/utils.py
+++ b/type_lens/utils.py
@@ -94,8 +94,8 @@ def unwrap_annotation(annotation: t.Any) -> tuple[t.Any, tuple[t.Any, ...], set[
         A tuple of the unwrapped annotation and any ``Annotated`` metadata, and a set of any wrapper types encountered.
     """
     origin = te.get_origin(annotation)
-    wrappers = set()
-    metadata = []
+    wrappers: set[t.Any] = set()
+    metadata: list[t.Any] = []
     while origin in _WRAPPER_TYPES:
         wrappers.add(origin)
         annotation, *meta = te.get_args(annotation)


### PR DESCRIPTION
The intent was to be sure we were not exposing pyright `Unknown` types out the public interface.

This goes beyond that and applies it to the whole repo, mainly because it's easier to ensure, if the whole repo is strictly enforced, and it wasn't that much more effort.